### PR TITLE
Add PatchInfo for Unity 2018.4 on macOS

### DIFF
--- a/Patcher/Program.cs
+++ b/Patcher/Program.cs
@@ -15,6 +15,12 @@ namespace Patcher
                 {
                     new PatchInfo
                     {
+                        Version = "2018.4",
+                        DarkPattern = new byte[] {0x75, 0x03, 0x41, 0x8B, 0x06, 0x4C, 0x3B},
+                        LightPattern = new byte[] {0x74, 0x03, 0x41, 0x8B, 0x06, 0x4C, 0x3B}
+                    },
+                    new PatchInfo
+                    {
                         Version = "2019.1.0f2",
                         DarkPattern = new byte[] {0x75, 0x03, 0x41, 0x8b, 0x06, 0x48},
                         LightPattern = new byte[] {0x74, 0x03, 0x41, 0x8b, 0x06, 0x48}

--- a/README.md
+++ b/README.md
@@ -3,16 +3,19 @@
 Unity Patch
 ===========
 
-This repository contains a patch for Unity that allows you to set options inacessible from the application's menus.
+This repository contains a patch for Unity that allows you to set options inaccessible from the application's menus.
 
 Currently, the only supported option for the patch is switching between the dark and light themes in Unity.
 
 Usage
 =====
 
-We provide binaries for Windows 10, Linux, and macOSX. All compiled binaries are x64. See the [release section](https://github.com/aevitas/unity-patch/releases). Alternatively, you can build the patch from source.
+We provide binaries for Windows 10, Linux, and macOS. All compiled binaries are x64.
+See the [release section](https://github.com/aevitas/unity-patch/releases).
+Alternatively, you can build the patch from source.
 
-Run `patcher.exe` on windows, or alternatively `Patcher` on Linux or MacOS. By default, it will locate your Unity install at `C:\Program Files\Unity\Editor\Unity.exe`, which is obviously wrong for both Linux and macOS, and it will set your theme to dark.
+Run `patcher.exe` on windows, or alternatively `Patcher` on Linux or MacOS. By default, it will locate your Unity install
+at `C:\Program Files\Unity\Editor\Unity.exe`, which is obviously wrong for both Linux and macOS, and it will set your theme to dark.
 
 You can pass various arguments to the patcher:
 
@@ -39,18 +42,13 @@ patcher.exe --windows --version=2020.1 --t=dark
 
 Currently, the following OS and Unity version combinations are supported:
 
-**Windows**
-* 2020.1
-* 2019.3
-* 2019.2.3f1
-
-**Linux**
-* 2019.2.3f
-
-**MacOS**
-* 2019.1.0f2
-* 2019.3 (tested until 2019.3.9f1)
-* 2020.1
+|        | Windows            | MacOS              | Linux              |
+|--------|:------------------:|:------------------:|:------------------:|
+| 2020.1 | :white_check_mark: | :white_check_mark: |         :x:        |
+| 2019.3 | :white_check_mark: | :white_check_mark: |         :x:        |
+| 2019.2 | :white_check_mark: |         :x:        | :white_check_mark: |
+| 2019.1 |         :x:        | :white_check_mark: |         :x:        | 
+| 2018.4 |         :x:        | :white_check_mark: |         :x:        |
 
 If you don't specify a version, the patcher will choose a default version.
 


### PR DESCRIPTION
Found the Hex Values which need to be patched for Unity 2018.4 on macOS. It made sense to me to include these since it's an LTS release and quite a few people will be using it for the foreseeable future.

I also fixed a typo in the Readme and reformatted the Supported Versions into a Table which makes it easier to read... at least in my opinion, if you want me to change it back I can gladly do so, just let me know. 