### PR TITLE
Add initial options file implementation

### DIFF
--- a/Patcher/Patcher.csproj
+++ b/Patcher/Patcher.csproj
@@ -10,4 +10,10 @@
     <Folder Include="Properties\PublishProfiles\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="options.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/Patcher/PatcherOptions.cs
+++ b/Patcher/PatcherOptions.cs
@@ -1,0 +1,15 @@
+﻿namespace Patcher
+{
+    public class PatcherOptions
+    {
+        public string ThemeName { get; set; }
+
+        public string FileLocation { get; set; }
+
+        public string Version { get; set; }
+
+        public OperatingSystem? OperatingSystem { get; set; }
+
+        public bool? Force { get; set; }
+    }
+}

--- a/Patcher/options.json
+++ b/Patcher/options.json
@@ -1,0 +1,7 @@
+﻿{
+  "ThemeName": "dark", 
+  "FileLocation": "",
+  "Version": "",
+  "OperatingSystem": null,
+  "Force": false
+}


### PR DESCRIPTION
Provides an `options.json` file which can contain user options, so that fewer command line arguments are required to run the patch.